### PR TITLE
[FIX] Logout errors from internal pages

### DIFF
--- a/Quiz.Site/Views/DashboardMaster.cshtml
+++ b/Quiz.Site/Views/DashboardMaster.cshtml
@@ -8,7 +8,7 @@
 @inject IMemberManager _memberManager;
 
 @{
-    Layout = null;
+    Layout = null;    
 }
 
 <!DOCTYPE html>

--- a/Quiz.Site/Views/LeaderboardPage.cshtml
+++ b/Quiz.Site/Views/LeaderboardPage.cshtml
@@ -1,9 +1,14 @@
-﻿@using Umbraco.Cms.Web.Common.PublishedModels;
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.LeaderboardPage>
+﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.LeaderboardPage>
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
-@using Umbraco.Cms.Core.Security
 
 @{
+	if(User.Identity != null && !User.Identity.IsAuthenticated)
+    {
+        this.Context.Response.Redirect("/");        
+        IgnoreBody();
+        return;
+    }
+
 	Layout = "DashboardMaster.cshtml";
 }
 

--- a/Quiz.Site/Views/QuestionListPage.cshtml
+++ b/Quiz.Site/Views/QuestionListPage.cshtml
@@ -6,6 +6,13 @@
 @inject IMemberManager memberManager
 
 @{
+	if(User.Identity != null && !User.Identity.IsAuthenticated)
+    {
+        this.Context.Response.Redirect("/");        
+        IgnoreBody();
+        return;
+    }
+	
 	Layout = "DashboardMaster.cshtml";
 	var member = await memberManager.GetCurrentMemberAsync();
 }

--- a/Quiz.Site/Views/QuestionSubmissionPage.cshtml
+++ b/Quiz.Site/Views/QuestionSubmissionPage.cshtml
@@ -2,6 +2,13 @@
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.QuestionSubmissionPage>
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
 @{
+	if(User.Identity != null && !User.Identity.IsAuthenticated)
+    {
+        this.Context.Response.Redirect("/");        
+        IgnoreBody();
+        return;
+    }
+	
 	Layout = "DashboardMaster.cshtml";
 }
 


### PR DESCRIPTION
When trying to logout from the Submit, My Questions, Leaderboard pages it results in a YSOD because none of the views check to verify if the member is logged in but all require an authenticated member.