### PR TITLE
Badging Engine Part #1 - Notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /Quiz.ContentModels/obj
 
 .vs/
+
+.idea/

--- a/Quiz.Site/Notifications/MemberRegisteredNotification.cs
+++ b/Quiz.Site/Notifications/MemberRegisteredNotification.cs
@@ -1,0 +1,14 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Quiz.Site.Notifications;
+
+public class MemberRegisteredNotification : INotification
+{
+    public IMember RegisteredMember { get; }
+
+    public MemberRegisteredNotification(IMember registeredMember)
+    {
+        RegisteredMember = registeredMember;
+    }
+}

--- a/Quiz.Site/Notifications/ProfileUpdatedNotification.cs
+++ b/Quiz.Site/Notifications/ProfileUpdatedNotification.cs
@@ -1,0 +1,14 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Quiz.Site.Notifications;
+
+public class ProfileUpdatedNotification : INotification
+{
+    public IMember UpdatedBy { get; }
+
+    public ProfileUpdatedNotification(IMember updatedBy)
+    {
+        UpdatedBy = updatedBy;
+    }
+}

--- a/Quiz.Site/Notifications/QuestionCreatedNotification.cs
+++ b/Quiz.Site/Notifications/QuestionCreatedNotification.cs
@@ -1,0 +1,14 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Quiz.Site.Notifications;
+
+public class QuestionCreatedNotification : INotification
+{
+    public IMember CreatedBy { get; }
+
+    public QuestionCreatedNotification(IMember createdBy)
+    {
+        CreatedBy = createdBy;
+    }
+}

--- a/Quiz.Site/Notifications/QuizCompletedNotification.cs
+++ b/Quiz.Site/Notifications/QuizCompletedNotification.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Quiz.Site.Notifications;
+
+public class QuizCompletedNotification : INotification
+{
+    public IMember Member { get; }
+    
+    public int QuizTotal { get; }
+
+    public int QuizScore { get; }
+    
+
+    public QuizCompletedNotification(IMember member, int quizTotal, int quizScore)
+    {
+        Member = member;
+        QuizTotal = quizTotal;
+        QuizScore = quizScore;
+    }
+}

--- a/Quiz.Site/Notifications/QuizCompletedNotification.cs
+++ b/Quiz.Site/Notifications/QuizCompletedNotification.cs
@@ -5,16 +5,15 @@ namespace Quiz.Site.Notifications;
 
 public class QuizCompletedNotification : INotification
 {
-    public IMember Member { get; }
+    public IMember CompletedBy { get; }
     
     public int QuizTotal { get; }
 
     public int QuizScore { get; }
-    
 
-    public QuizCompletedNotification(IMember member, int quizTotal, int quizScore)
+    public QuizCompletedNotification(IMember completedBy, int quizTotal, int quizScore)
     {
-        Member = member;
+        CompletedBy = completedBy;
         QuizTotal = quizTotal;
         QuizScore = quizScore;
     }

--- a/Quiz.Site/Quiz.Site.csproj
+++ b/Quiz.Site/Quiz.Site.csproj
@@ -28,6 +28,10 @@
     <ProjectReference Include="..\Quiz.ContentModels\Quiz.ContentModels.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="NotificationHandlers" />
+  </ItemGroup>
+
   <!-- Keep this as false if ModelsBuilder mode is InMemoryAuto -->
   <PropertyGroup>
     <RazorCompileOnBuild>true</RazorCompileOnBuild>


### PR DESCRIPTION
As per issue #14, the first steps into creating a Badging Engine would be to fire specific events throughout the Umbraco application. For now I have only created the Notifications nessecary for the currently implemented badges, but in the future new notifications can easily be added when needed! 

I've tested this out with some various NotificationHandlers, but removed them for the sake of this pullrequest, as we can continue working on the handler implementation later on 🙂