### PR TITLE
Added the text-danger class to form validation spans

### DIFF
--- a/Quiz.Site/Views/Components/SubmitQuestion/Default.cshtml
+++ b/Quiz.Site/Views/Components/SubmitQuestion/Default.cshtml
@@ -37,32 +37,32 @@
             <label asp-for="@Model.QuestionText"></label>
             <div class="mb-3">
                 <textarea asp-for="@Model.QuestionText" type="text" class="form-control" placeholder="Question Text" aria-label="Question Text"></textarea>
-                <span asp-validation-for="@Model.QuestionText"></span>
+                <span asp-validation-for="@Model.QuestionText" class="text-danger"></span>
             </div>
             <label asp-for="@Model.CorrectAnswer" class="text-success"></label>
             <div class="mb-3">
                 <input asp-for="@Model.CorrectAnswer" type="text" class="form-control" placeholder="Correct Answer" aria-label="CorrectAnswer">
-                <span asp-validation-for="@Model.CorrectAnswer"></span>
+                <span asp-validation-for="@Model.CorrectAnswer" class="text-danger"></span>
             </div>
             <label asp-for="@Model.WrongAnswer1" class="text-danger"></label>
             <div class="mb-3">
                 <input asp-for="@Model.WrongAnswer1" type="text" class="form-control" placeholder="Wrong Answer 1" aria-label="Wrong Answer 1">
-                <span asp-validation-for="@Model.WrongAnswer1"></span>
+                <span asp-validation-for="@Model.WrongAnswer1" class="text-danger"></span>
             </div>
             <label asp-for="@Model.WrongAnswer2" class="text-danger"></label>
             <div class="mb-3">
                 <input asp-for="@Model.WrongAnswer2" type="text" class="form-control" placeholder="Wrong Answer 2" aria-label="Wrong Answer 2">
-                <span asp-validation-for="@Model.WrongAnswer2"></span>
+                <span asp-validation-for="@Model.WrongAnswer2" class="text-danger"></span>
             </div>
             <label asp-for="@Model.WrongAnswer3" class="text-danger"></label>
             <div class="mb-3">
                 <input asp-for="@Model.WrongAnswer3" type="text" class="form-control" placeholder="Wrong Answer 3" aria-label="Wrong Answer 3">
-                <span asp-validation-for="@Model.WrongAnswer3"></span>
+                <span asp-validation-for="@Model.WrongAnswer3" class="text-danger"></span>
             </div>
             <label asp-for="@Model.MoreInfoLink"></label>
             <div class="mb-3">
                 <input asp-for="@Model.MoreInfoLink" type="text" class="form-control" placeholder="More Info Link" aria-label="More Info Link">
-                <span asp-validation-for="@Model.MoreInfoLink"></span>
+                <span asp-validation-for="@Model.MoreInfoLink" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <button class="btn btn-primary btn-block btn-lg" type="submit">Submit</button>


### PR DESCRIPTION
shows what the problem was: 
https://github.com/prjseal/Umbraco-Community-Quiz/issues/4

how you fixed it: 
Searched for forms within the project, found the validation on the Submit form that was missing the text-danger class & added this there. 

 and what happens now.
Tested locally - if a Submit form is submitted with empty fields, the validation text will appear with the text-danger styling. Once valid text is entered, the validation clears.