### PR TITLE
Security header hardening

### DIFF
--- a/Quiz.Site/Middleware/SecurityHeadersMiddleware.cs
+++ b/Quiz.Site/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,23 @@
+﻿namespace Quiz.Site.Middleware;
+
+public sealed class SecurityHeadersMiddleware
+{
+    private readonly RequestDelegate _next;
+    public SecurityHeadersMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+    public Task Invoke(HttpContext context)
+    {
+        context.Response.Headers.Add("referrer-policy", "no-referrer");
+        context.Response.Headers.Add("x-content-type-options", "nosniff");
+        context.Response.Headers.Add("x-frame-options", "DENY");
+        context.Response.Headers.Add("X-Permitted-Cross-Domain-Policies", "none");
+        context.Response.Headers.Add("x-xss-protection", "1; mode=block");
+        context.Response.Headers.Add("cross-origin-opener-policy", "same-origin");
+        context.Response.Headers.Add("Permissions-Policy","accelerometer=(),autoplay=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),midi=(),payment=(),picture-in-picture=(),publickey-credentials-get=(),screen-wake-lock=(),sync-xhr=(self),usb=(),web-share=(),xr-spatial-tracking=()");
+        /*context.Response.Headers.Add("Content-Security-Policy", "");*/
+
+        return _next(context);
+    }
+}

--- a/Quiz.Site/Startup.cs
+++ b/Quiz.Site/Startup.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.HttpOverrides;
+using Quiz.Site.Middleware;
 
 namespace Quiz.Site
 {
@@ -35,6 +36,13 @@ namespace Quiz.Site
                 options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
             });
 
+            services.AddHsts(options =>
+            {
+                options.MaxAge = TimeSpan.FromDays(90);
+                options.IncludeSubDomains = true;
+                options.Preload = true;
+            });
+
             services.AddUmbraco(_env, _config)
                 .AddBackOffice()
                 .AddWebsite()
@@ -59,8 +67,9 @@ namespace Quiz.Site
             else
             {
                 app.UseExceptionHandler("/error.html");
+                app.UseHsts();
             }
-
+            app.UseMiddleware<SecurityHeadersMiddleware>();
 
             app.UseUmbraco()
                 .WithMiddleware(u => {


### PR DESCRIPTION
- Enabled HSTS
- Added response headers
- CSP Header has been commented out as I don't know what urls to apply
- X Powered By and Server headers need to be removed at Server level they cannot be removed in C#. (This may be achievable during deployment where the Web.Config is updated. )