### PR TITLE
Remove explicit reference to content app html file

### DIFF
--- a/Quiz.Site/Quiz.Site.csproj
+++ b/Quiz.Site/Quiz.Site.csproj
@@ -6,9 +6,6 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 	<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
-  <ItemGroup>
-    <Content Include="App_Plugins\UsedQuestions\usedQuestions.html" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Konstrukt" Version="1.5.2" />


### PR DESCRIPTION
Remove the reference to the content app html file so it gets deployed correctly instead of not putting it in the correct location. .Net Core + doesn't need the explicit reference any more.